### PR TITLE
added iOS 7 support.

### DIFF
--- a/PullToRefreshDemo/MSPullToRefreshController.h
+++ b/PullToRefreshDemo/MSPullToRefreshController.h
@@ -82,6 +82,9 @@ typedef enum {
     
     // used internally to capture the did end dragging state
     BOOL _wasDragging;
+    
+    // scroll view's original content inset before refresh sequence
+    UIEdgeInsets _originalScrollViewContentInset;
 }
 
 /*

--- a/PullToRefreshDemo/MSPullToRefreshController.m
+++ b/PullToRefreshDemo/MSPullToRefreshController.m
@@ -83,8 +83,9 @@
         case MSRefreshDirectionTop:
             refreshableDirection = MSRefreshableDirectionTop;
             refreshingDirection = MSRefreshingDirectionTop;
-            contentInset = UIEdgeInsetsMake(refreshingInset, contentInset.left, contentInset.bottom, contentInset.right);
-            contentOffset = CGPointMake(0, -refreshingInset);
+            CGFloat originalContentOffsetY = -contentInset.top;
+            contentInset = UIEdgeInsetsMake(contentInset.top + refreshingInset, contentInset.left, contentInset.bottom, contentInset.right);
+            contentOffset = CGPointMake(0, -refreshingInset+originalContentOffsetY);
             break;
         case MSRefreshDirectionLeft:
             refreshableDirection = MSRefreshableDirectionLeft;
@@ -112,6 +113,7 @@
         [UIView beginAnimations:nil context:NULL];
         [UIView setAnimationDuration:0.2];
     }
+    _originalScrollViewContentInset = _scrollView.contentInset;
     _scrollView.contentInset = contentInset;
     _scrollView.contentOffset = contentOffset;
 
@@ -136,7 +138,7 @@
     switch (direction) {
         case MSRefreshDirectionTop:
             refreshingDirection = MSRefreshingDirectionTop;
-            contentInset = UIEdgeInsetsMake(0, contentInset.left, contentInset.bottom, contentInset.right);
+            contentInset = UIEdgeInsetsMake(_originalScrollViewContentInset.top, contentInset.left, contentInset.bottom, contentInset.right);
             break;
         case MSRefreshDirectionLeft:
             refreshingDirection = MSRefreshingDirectionLeft;
@@ -189,8 +191,8 @@
         case MSRefreshDirectionTop:
             refreshingDirection = MSRefreshingDirectionTop;
             refreshableDirection = MSRefreshableDirectionTop;
-            canEngage = oldOffset.y < - refreshableInset;
-            contentInset = UIEdgeInsetsMake(refreshingInset, contentInset.left, contentInset.bottom, contentInset.right);
+            canEngage = oldOffset.y < - refreshableInset - _scrollView.contentInset.top;
+            contentInset = UIEdgeInsetsMake(contentInset.top + refreshingInset, contentInset.left, contentInset.bottom, contentInset.right);
             break;
         case MSRefreshDirectionLeft:
             refreshingDirection = MSRefreshingDirectionLeft;
@@ -223,6 +225,7 @@
                 // if you are decelerating, it means you've stopped dragging.
                 self.refreshingDirections |= refreshingDirection;
                 self.refreshableDirections &= ~refreshableDirection;
+                _originalScrollViewContentInset = _scrollView.contentInset;
                 _scrollView.contentInset = contentInset;
                 if ([_delegate respondsToSelector:@selector(pullToRefreshController:didEngageRefreshDirection:)]) {
                     [_delegate pullToRefreshController:self didEngageRefreshDirection:direction];


### PR DESCRIPTION
bogardon & timothy1ee,

Thanks for the nice library.
I'm using this to support the application that have to run with iOS 5, that cannot use iOS 6's `UIRefreshControll`.

BTW, in iOS 7, I confirmed the `contentInset` of `UIScrollView` under `UINavigationController` may be not `{0, 0, 0, 0}`. Because in iOS 7, the `UINavigationBar` of `UINavigationController` is transparent, therefore `UIScrollView` has initial `contentInset` for this `UINavigationBar` area. In this case, the default `contentInset` is like `{64, 0, 0, 0}`, and also `contentOffset` is not `{0, 0}`, but like `{0, -64}`.

For supporting iOS 7, it's not always true that we can set `0` to `UIScrollView`'s `contentInset` to restore `UIScrollView`'s state in `finishRefreshingDirection:animated:`.

Can you check this pull request?

Thanks in advance for your supports.
honishi
