### PR TITLE
Restore original inset based on finish direction.

### DIFF
--- a/PullToRefreshDemo/MSPullToRefreshController.m
+++ b/PullToRefreshDemo/MSPullToRefreshController.m
@@ -142,15 +142,15 @@
             break;
         case MSRefreshDirectionLeft:
             refreshingDirection = MSRefreshingDirectionLeft;
-            contentInset = UIEdgeInsetsMake(contentInset.top, 0, contentInset.bottom, contentInset.right);
+            contentInset = UIEdgeInsetsMake(contentInset.top, _originalScrollViewContentInset.left, contentInset.bottom, contentInset.right);
             break;
         case MSRefreshDirectionBottom:
             refreshingDirection = MSRefreshingDirectionBottom;
-            contentInset = UIEdgeInsetsMake(contentInset.top, contentInset.left, 0, contentInset.right);
+            contentInset = UIEdgeInsetsMake(contentInset.top, contentInset.left, _originalScrollViewContentInset.top, contentInset.right);
             break;
         case MSRefreshDirectionRight:
             refreshingDirection = MSRefreshingDirectionRight;
-            contentInset = UIEdgeInsetsMake(contentInset.top, contentInset.left, contentInset.bottom, 0);
+            contentInset = UIEdgeInsetsMake(contentInset.top, contentInset.left, contentInset.bottom, _originalScrollViewContentInset.right);
             break;
         default:
             break;


### PR DESCRIPTION
When pull to refresh finishes, now it will restore correct inset for direction (When direction is left, it will restore the left inset from original inset).
